### PR TITLE
Mattg/set-stream-info

### DIFF
--- a/apps/rpicam_raw.cpp
+++ b/apps/rpicam_raw.cpp
@@ -55,7 +55,7 @@ static void event_loop(LibcameraRaw &app)
 		if (count == 0)
 		{
 			StreamInfo info = app.GetStreamInfo(app.RawStream())
-			output.get().setStreamInfo(info)
+			output.get()->setStreamInfo(info)
 			libcamera::StreamConfiguration const &cfg = app.RawStream()->configuration();
 			LOG(1, "Raw stream: " << cfg.size.width << "x" << cfg.size.height << " stride " << cfg.stride << " format "
 								  << cfg.pixelFormat.toString());

--- a/apps/rpicam_raw.cpp
+++ b/apps/rpicam_raw.cpp
@@ -55,7 +55,7 @@ static void event_loop(LibcameraRaw &app)
 		if (count == 0)
 		{
 			StreamInfo info = app.GetStreamInfo(app.RawStream());
-			output.get()->setStreamInfo(info);
+			output.get()->setStreamInfo(&info);
 			libcamera::StreamConfiguration const &cfg = app.RawStream()->configuration();
 			LOG(1, "Raw stream: " << cfg.size.width << "x" << cfg.size.height << " stride " << cfg.stride << " format "
 								  << cfg.pixelFormat.toString());

--- a/apps/rpicam_raw.cpp
+++ b/apps/rpicam_raw.cpp
@@ -54,8 +54,8 @@ static void event_loop(LibcameraRaw &app)
 			throw std::runtime_error("unrecognised message!");
 		if (count == 0)
 		{
-			StreamInfo info = app.GetStreamInfo(app.RawStream())
-			output.get()->setStreamInfo(info)
+			StreamInfo info = app.GetStreamInfo(app.RawStream());
+			output.get()->setStreamInfo(info);
 			libcamera::StreamConfiguration const &cfg = app.RawStream()->configuration();
 			LOG(1, "Raw stream: " << cfg.size.width << "x" << cfg.size.height << " stride " << cfg.stride << " format "
 								  << cfg.pixelFormat.toString());

--- a/apps/rpicam_raw.cpp
+++ b/apps/rpicam_raw.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 
 #include "core/rpicam_encoder.hpp"
+#include "core/stream_info.hpp"
 #include "encoder/null_encoder.hpp"
 #include "output/output.hpp"
 
@@ -53,6 +54,8 @@ static void event_loop(LibcameraRaw &app)
 			throw std::runtime_error("unrecognised message!");
 		if (count == 0)
 		{
+			StreamInfo info = app.GetStreamInfo(app.RawStream())
+			output.get().setStreamInfo(info)
 			libcamera::StreamConfiguration const &cfg = app.RawStream()->configuration();
 			LOG(1, "Raw stream: " << cfg.size.width << "x" << cfg.size.height << " stride " << cfg.stride << " format "
 								  << cfg.pixelFormat.toString());

--- a/apps/rpicam_still.cpp
+++ b/apps/rpicam_still.cpp
@@ -86,7 +86,7 @@ static void save_image(RPiCamStillApp &app, CompletedRequestPtr &payload, Stream
 	BufferReadSync r(&app, payload->buffers[stream]);
 	const std::vector<libcamera::Span<uint8_t>> mem = r.Get();
 	if (stream == app.RawStream())
-		dng_save(mem[0].data(), info, payload->metadata, filename, app.CameraModel(), static_cast<Options*>(options));
+		dng_save(mem[0].data(), info, payload->metadata, filename, app.CameraModel(), static_cast<const Options*>(options));
 	else if (options->encoding == "jpg")
 		jpeg_save(mem, info, payload->metadata, filename, app.CameraModel(), options);
 	else if (options->encoding == "png")

--- a/apps/rpicam_still.cpp
+++ b/apps/rpicam_still.cpp
@@ -86,7 +86,7 @@ static void save_image(RPiCamStillApp &app, CompletedRequestPtr &payload, Stream
 	BufferReadSync r(&app, payload->buffers[stream]);
 	const std::vector<libcamera::Span<uint8_t>> mem = r.Get();
 	if (stream == app.RawStream())
-		dng_save(mem[0].data(), info, payload->metadata, filename, app.CameraModel(), static_cast<const Options*>(options));
+		dng_save(mem[0].data(), info, payload->metadata, filename, app.CameraModel(), (const Options*)options);
 	else if (options->encoding == "jpg")
 		jpeg_save(mem, info, payload->metadata, filename, app.CameraModel(), options);
 	else if (options->encoding == "png")

--- a/apps/rpicam_still.cpp
+++ b/apps/rpicam_still.cpp
@@ -16,6 +16,7 @@
 #include "core/frame_info.hpp"
 #include "core/rpicam_app.hpp"
 #include "core/still_options.hpp"
+#include "core/options.hpp"
 
 #include "output/output.hpp"
 
@@ -85,7 +86,7 @@ static void save_image(RPiCamStillApp &app, CompletedRequestPtr &payload, Stream
 	BufferReadSync r(&app, payload->buffers[stream]);
 	const std::vector<libcamera::Span<uint8_t>> mem = r.Get();
 	if (stream == app.RawStream())
-		dng_save(mem[0].data(), info, payload->metadata, filename, app.CameraModel(), options);
+		dng_save(mem[0].data(), info, payload->metadata, filename, app.CameraModel(), static_cast<Options*>(options));
 	else if (options->encoding == "jpg")
 		jpeg_save(mem, info, payload->metadata, filename, app.CameraModel(), options);
 	else if (options->encoding == "png")

--- a/apps/rpicam_still.cpp
+++ b/apps/rpicam_still.cpp
@@ -86,7 +86,7 @@ static void save_image(RPiCamStillApp &app, CompletedRequestPtr &payload, Stream
 	BufferReadSync r(&app, payload->buffers[stream]);
 	const std::vector<libcamera::Span<uint8_t>> mem = r.Get();
 	if (stream == app.RawStream())
-		dng_save(mem[0].data(), info, payload->metadata, filename, app.CameraModel(), (const Options*)options);
+		dng_save(mem[0].data(), info, payload->metadata, filename, app.CameraModel(), options);
 	else if (options->encoding == "jpg")
 		jpeg_save(mem, info, payload->metadata, filename, app.CameraModel(), options);
 	else if (options->encoding == "png")

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -347,6 +347,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	unsigned int buf_stride_pixels_padded = (buf_stride_pixels + 7) & ~7;
 	// 1.5 for 12 bit, 1.25 for 10 bit
 	double bytesPerPixel = (double)bayer_format.bits / 8.0;
+	int bitsPerPixel = 16;
 	std::vector<uint8_t> buf8bit(int(info.width * bytesPerPixel * info.height));
 	std::vector<uint16_t> buf16Bit(buf_stride_pixels_padded * info.height);
 	if (bayer_format.compressed)
@@ -360,9 +361,11 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		switch (bayer_format.bits)
 		{
 		case 10:
+			bitsPerPixel = 10;
 			unpack_10bit((uint8_t const*)mem, info, &buf8bit[0], &buf16Bit[0]);
 			break;
 		case 12:
+			bitsPerPixel = 12;
 			unpack_12bit((uint8_t const*)mem, info, &buf8bit[0], &buf16Bit[0]);
 			break;
 		}
@@ -511,7 +514,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		TIFFSetField(tif, TIFFTAG_IMAGELENGTH, info.height);
 		// TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, bitsPerSample);
 		// TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 16);
-		TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 12);
+		TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, bitsPerPixel);
 		TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_CFA);
 		TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
 		TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -478,11 +478,13 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		if (!tif)
 			throw std::runtime_error("could not open file " + filename);
 
+		// Original multiplier was 4
+		unsigned int grayscaleMultiplier = 5;
 		// This is just the thumbnail, but put it first to help software that only
 		// reads the first IFD.
 		TIFFSetField(tif, TIFFTAG_SUBFILETYPE, 1);
-		TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, info.width >> 4);
-		TIFFSetField(tif, TIFFTAG_IMAGELENGTH, info.height >> 4);
+		TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, info.width >> grayscaleMultiplier);
+		TIFFSetField(tif, TIFFTAG_IMAGELENGTH, info.height >> grayscaleMultiplier);
 		TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 8);
 		TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
 		TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
@@ -502,8 +504,6 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		TIFFSetField(tif, TIFFTAG_EXIFIFD, offset_exififd);
 
 		// Make a small greyscale thumbnail, just to give some clue what's in here.
-		// Original multiplier was 4
-		unsigned int grayscaleMultiplier = 5;
 		std::vector<uint8_t> thumb_buf((info.width >> grayscaleMultiplier) * 3);
 
 		for (unsigned int y = 0; y < (info.height >> grayscaleMultiplier); y++)

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -341,6 +341,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		throw std::runtime_error("unsupported Bayer format");
 	BayerFormat const &bayer_format = it->second;
 	LOG(1, "Bayer format is " << bayer_format.name);
+	std::cout << "!!!!cout!!!!!" << std::endl;
 
 	// Decompression will require a buffer that's 8 pixels aligned.
 	unsigned int buf_stride_pixels = info.width;

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -348,6 +348,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	double bytesPerPixel = bayer_format.bits / 8;
 	std::vector<uint8_t> buf8bit(info.width * bytesPerPixel * info.height);
 	std::vector<uint16_t> buf16Bit(buf_stride_pixels_padded * info.height);
+	std::cout << "!!!!BEFORE!!!!!" << std::endl;
 	if (bayer_format.compressed)
 	{
 		uncompress((uint8_t const*)mem, info, &buf16Bit[0]);
@@ -369,6 +370,8 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	else {
 		unpack_16bit((uint8_t const*)mem, info, &buf16Bit[0]);
 	}
+
+	std::cout << "!!!!!!AFTER!!!!!!" << std::endl;
 
 	// We need to fish out some metadata values for the DNG.
 	// float black = 4096 * (1 << bayer_format.bits) / 65536.0;

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -347,7 +347,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	unsigned int buf_stride_pixels = info.width;
 	unsigned int buf_stride_pixels_padded = (buf_stride_pixels + 7) & ~7;
 	double bytesPerPixel = bayer_format.bits / 8;
-	cout << "got bytes per pixel: " >> bytesPerPixel << endl;
+	std::cout << "got bytes per pixel: " >> bytesPerPixel << std::endl;
 	std::vector<uint8_t> buf8bit(int(info.width * bytesPerPixel * info.height) + 1000);
 	std::vector<uint16_t> buf16Bit(buf_stride_pixels_padded * info.height);
 	std::cout << "!!!!BEFORE!!!!!" << std::endl;

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -547,8 +547,6 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		TIFFSetField(tif, TIFFTAG_SUBFILETYPE, 0);
 		TIFFSetField(tif, TIFFTAG_IMAGEWIDTH, width);
 		TIFFSetField(tif, TIFFTAG_IMAGELENGTH, height);
-		// TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, bitsPerSample);
-		// TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 16);
 		TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, bitsPerPixel);
 		TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_CFA);
 		TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 1);
@@ -564,7 +562,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		TIFFSetField(tif, TIFFTAG_BLACKLEVELREPEATDIM, &black_level_repeat_dim);
 		TIFFSetField(tif, TIFFTAG_BLACKLEVEL, 4, &black_levels);
 
-		unsigned int rowNum = 0
+		unsigned int rowNum = 0;
 		for (unsigned int y = startY; y < endY; y++)
 		{
 			unsigned int rowStartLocation = info.width * bytesPerPixel * y;

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -15,6 +15,7 @@
 #include <tiffio.h>
 
 #include "core/still_options.hpp"
+#include "core/options.hpp"
 #include "core/stream_info.hpp"
 
 #ifndef MAKE_STRING
@@ -332,7 +333,7 @@ Matrix(float m0, float m1, float m2,
 };
 
 void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
-			  std::string const &filename, std::string const &cam_model, StillOptions const *options)
+			  std::string const &filename, std::string const &cam_model, Options const *options)
 {
 	// Check the Bayer format and unpack it to u16.
 	auto it = bayer_formats.find(info.pixel_format);
@@ -372,7 +373,6 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		unpack_16bit((uint8_t const*)mem, info, &buf16Bit[0]);
 	}
 
-	std::cout << "got bpp: " << bitsPerPixel << std::endl;
 	// We need to fish out some metadata values for the DNG.
 	float black = 4096 * (1 << bayer_format.bits) / 65536.0;
 	float black_levels[] = { black, black, black, black };

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -333,7 +333,7 @@ Matrix(float m0, float m1, float m2,
 };
 
 void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
-			  std::string const &filename, std::string const &cam_model, Options const *options)
+			  std::string const &filename, std::string const &cam_model, const Options *options)
 {
 	// Check the Bayer format and unpack it to u16.
 	auto it = bayer_formats.find(info.pixel_format);

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -333,7 +333,7 @@ Matrix(float m0, float m1, float m2,
 };
 
 void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
-			  std::string const &filename, std::string const &cam_model, const Options *options)
+			  std::string const &filename, std::string const &cam_model, Options const *options)
 {
 	// Check the Bayer format and unpack it to u16.
 	auto it = bayer_formats.find(info.pixel_format);

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -347,6 +347,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	unsigned int buf_stride_pixels = info.width;
 	unsigned int buf_stride_pixels_padded = (buf_stride_pixels + 7) & ~7;
 	double bytesPerPixel = bayer_format.bits / 8;
+	cout << "got bytes per pixel: " >> bytesPerPixel << endl;
 	std::vector<uint8_t> buf8bit(int(info.width * bytesPerPixel * info.height) + 1000);
 	std::vector<uint16_t> buf16Bit(buf_stride_pixels_padded * info.height);
 	std::cout << "!!!!BEFORE!!!!!" << std::endl;

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -346,7 +346,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	// Decompression will require a buffer that's 8 pixels aligned.
 	unsigned int buf_stride_pixels = info.width;
 	unsigned int buf_stride_pixels_padded = (buf_stride_pixels + 7) & ~7;
-	double bytesPerPixel = bayer_format.bits / 8;
+	double bytesPerPixel = (double)bayer_format.bits / 8.0;
 	std::cout << "got bytes per pixel: " << bytesPerPixel << std::endl;
 	std::vector<uint8_t> buf8bit(int(info.width * bytesPerPixel * info.height) + 1000);
 	std::vector<uint16_t> buf16Bit(buf_stride_pixels_padded * info.height);

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -524,14 +524,10 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 
 		if(width == 0) {
 			width = info.width - startX;
-		} else {
-			width -= startX;
 		}
 
 		if(height == 0) {
 			height = info.height;
-		} else {
-			height -= startY;
 		}
 
 		unsigned int endX = startX + width;

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -564,27 +564,14 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		TIFFSetField(tif, TIFFTAG_BLACKLEVELREPEATDIM, &black_level_repeat_dim);
 		TIFFSetField(tif, TIFFTAG_BLACKLEVEL, 4, &black_levels);
 
-		// for (unsigned int y = 0; y < info.height; y++)
-		// {
-		// 	if (TIFFWriteScanline(tif, &buf8bit[(info.width * bytesPerPixel) * y], y, 0) != 1)
-		// 		throw std::runtime_error("error writing DNG image data");
-		// }
-
-		std::cout << "startX: " << startX << std::endl;
-		std::cout << "endX: " << endX << std::endl;
-		std::cout << "startY: " << startY << std::endl;
-		std::cout << "endY: " << endY << std::endl;
-		std::cout << "width: " << width << std::endl;
-		std::cout << "height: " << height << std::endl;
-		std::cout << "roix: " << options->roi_x << std::endl;
-		std::cout << "roiy: " << options->roi_y << std::endl;
-		std::cout << "roi_width: " << options->roi_width << std::endl;
-		std::cout << "roi_height: " << options->roi_height << std::endl;
-
+		unsigned int rowNum = 0
 		for (unsigned int y = startY; y < endY; y++)
 		{
-			if (TIFFWriteScanline(tif, &buf8bit[((info.width * bytesPerPixel) * y) + (startX * bytesPerPixel)], y - startY, 0) != 1)
+			unsigned int rowStartLocation = info.width * bytesPerPixel * y;
+			unsigned int roiOffset = startX * bytesPerPixel;
+			if (TIFFWriteScanline(tif, &buf8bit[rowStartLocation + roiOffset], rowNum, 0) != 1)
 				throw std::runtime_error("error writing DNG image data");
+			rowNum++;
 		}
 
 		// We have to checkpoint before the directory offset is valid.

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -96,40 +96,40 @@ static void unpack_10bit(uint8_t const *src, StreamInfo const &info, uint16_t *d
 	}
 }
 
-static void unpack_10bit_as_8_bit_byte(uint8_t const *src, StreamInfo const &info, uint8_t *dest)
-{
-	unsigned int w_align = info.width & ~3;
-	for (unsigned int y = 0; y < info.height; y++, src += info.stride)
-	{
-		uint8_t const *ptr = src;
-		unsigned int x;
-		for (x = 0; x < w_align; x += 4, ptr += 5)
-		{
-			uint16_t val1 = (ptr[0] << 2) | ((ptr[4] >> 0) & 3);
-			uint16_t val2 = (ptr[1] << 2) | ((ptr[4] >> 2) & 3);
-			uint16_t val3 = (ptr[2] << 2) | ((ptr[4] >> 4) & 3);
-			uint16_t val4 = (ptr[3] << 2) | ((ptr[4] >> 6) & 3);
-			// Cut off the 2 LSB
-			uint8_t byte1 = val1 >> 2;
-			// get the 2 LSB of the val1, or'd with the 6 MSB of val2
-			uint8_t byte2 = ((val1 & 3) << 6) | (val2 >> 4);
-			// get the 4 LSB of val2 or'd with 4 MSB of val3
-			uint8_t byte3 = ((val2 & 0xf) << 4) | (val3 >> 6);
-			// get the 6 LSB of val3 abd the 2 MSB of val4
-			uint8_t byte4 = ((val3 & 0x3f) << 2) | (val4 >> 8);
-			// get 8 LSB of val4
-			uint8_t byte5 = val4 & 0xff;
+// static void unpack_10bit_as_8_bit_byte(uint8_t const *src, StreamInfo const &info, uint8_t *dest)
+// {
+// 	unsigned int w_align = info.width & ~3;
+// 	for (unsigned int y = 0; y < info.height; y++, src += info.stride)
+// 	{
+// 		uint8_t const *ptr = src;
+// 		unsigned int x;
+// 		for (x = 0; x < w_align; x += 4, ptr += 5)
+// 		{
+// 			uint16_t val1 = (ptr[0] << 2) | ((ptr[4] >> 0) & 3);
+// 			uint16_t val2 = (ptr[1] << 2) | ((ptr[4] >> 2) & 3);
+// 			uint16_t val3 = (ptr[2] << 2) | ((ptr[4] >> 4) & 3);
+// 			uint16_t val4 = (ptr[3] << 2) | ((ptr[4] >> 6) & 3);
+// 			// Cut off the 2 LSB
+// 			uint8_t byte1 = val1 >> 2;
+// 			// get the 2 LSB of the val1, or'd with the 6 MSB of val2
+// 			uint8_t byte2 = ((val1 & 3) << 6) | (val2 >> 4);
+// 			// get the 4 LSB of val2 or'd with 4 MSB of val3
+// 			uint8_t byte3 = ((val2 & 0xf) << 4) | (val3 >> 6);
+// 			// get the 6 LSB of val3 abd the 2 MSB of val4
+// 			uint8_t byte4 = ((val3 & 0x3f) << 2) | (val4 >> 8);
+// 			// get 8 LSB of val4
+// 			uint8_t byte5 = val4 & 0xff;
 
-			*dest++ = byte1;
-			*dest++ = byte2;
-			*dest++ = byte3;
-			*dest++ = byte4;
-			*dest++ = byte5;
-		}
-		for (; x < info.width; x++)
-			*dest++ = (ptr[x & 3] << 2) | ((ptr[4] >> ((x & 3) << 1)) & 3);
-	}
-}
+// 			*dest++ = byte1;
+// 			*dest++ = byte2;
+// 			*dest++ = byte3;
+// 			*dest++ = byte4;
+// 			*dest++ = byte5;
+// 		}
+// 		for (; x < info.width; x++)
+// 			*dest++ = (ptr[x & 3] << 2) | ((ptr[4] >> ((x & 3) << 1)) & 3);
+// 	}
+// }
 
 static void unpack_12bit(uint8_t const *src, StreamInfo const &info, uint16_t *dest)
 {

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -357,15 +357,13 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	}
 	else if (bayer_format.packed)
 	{
-		// bitsPerSample = bayer_format.bits;
+		bitsPerPixel = bayer_format.bits;
 		switch (bayer_format.bits)
 		{
 		case 10:
-			bitsPerPixel = 10;
 			unpack_10bit((uint8_t const*)mem, info, &buf8bit[0], &buf16Bit[0]);
 			break;
 		case 12:
-			bitsPerPixel = 12;
 			unpack_12bit((uint8_t const*)mem, info, &buf8bit[0], &buf16Bit[0]);
 			break;
 		}
@@ -374,6 +372,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		unpack_16bit((uint8_t const*)mem, info, &buf16Bit[0]);
 	}
 
+	std::cout << "got bpp: " << bitsPerPixel << std::endl;
 	// We need to fish out some metadata values for the DNG.
 	float black = 4096 * (1 << bayer_format.bits) / 65536.0;
 	float black_levels[] = { black, black, black, black };

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -346,7 +346,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	unsigned int buf_stride_pixels = info.width;
 	unsigned int buf_stride_pixels_padded = (buf_stride_pixels + 7) & ~7;
 	double bytesPerPixel = bayer_format.bits / 8;
-	std::vector<uint8_t> buf8bit(info.width * bytesPerPixel * info.height);
+	std::vector<uint8_t> buf8bit(int(info.width * bytesPerPixel * info.height));
 	std::vector<uint16_t> buf16Bit(buf_stride_pixels_padded * info.height);
 	std::cout << "!!!!BEFORE!!!!!" << std::endl;
 	if (bayer_format.compressed)

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -347,7 +347,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	unsigned int buf_stride_pixels = info.width;
 	unsigned int buf_stride_pixels_padded = (buf_stride_pixels + 7) & ~7;
 	double bytesPerPixel = bayer_format.bits / 8;
-	std::vector<uint8_t> buf8bit(int(info.width * bytesPerPixel * info.height));
+	std::vector<uint8_t> buf8bit(int(info.width * bytesPerPixel * info.height) + 1000);
 	std::vector<uint16_t> buf16Bit(buf_stride_pixels_padded * info.height);
 	std::cout << "!!!!BEFORE!!!!!" << std::endl;
 	if (bayer_format.compressed)

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -347,7 +347,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 	unsigned int buf_stride_pixels = info.width;
 	unsigned int buf_stride_pixels_padded = (buf_stride_pixels + 7) & ~7;
 	double bytesPerPixel = bayer_format.bits / 8;
-	std::cout << "got bytes per pixel: " >> bytesPerPixel << std::endl;
+	std::cout << "got bytes per pixel: " << bytesPerPixel << std::endl;
 	std::vector<uint8_t> buf8bit(int(info.width * bytesPerPixel * info.height) + 1000);
 	std::vector<uint16_t> buf16Bit(buf_stride_pixels_padded * info.height);
 	std::cout << "!!!!BEFORE!!!!!" << std::endl;

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -583,7 +583,7 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 
 		for (unsigned int y = startY; y < endY; y++)
 		{
-			if (TIFFWriteScanline(tif, &buf8bit[((info.width * bytesPerPixel) * y) + (startX * bytesPerPixel)], y, 0) != 1)
+			if (TIFFWriteScanline(tif, &buf8bit[((info.width * bytesPerPixel) * y) + (startX * bytesPerPixel)], y - startY, 0) != 1)
 				throw std::runtime_error("error writing DNG image data");
 		}
 

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -515,11 +515,11 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		if(bitsPerPixel == 10) {
 			// 4 pixels and packed into 5 bytes so go back to the the location where
 			// the a byte holds 8 MSB of a pixel
-			startX -= startX % 5;
+			startX -= startX % 4;
 		} else if (bitsPerPixel == 12) {
 			// 2 pixels and packed into 3 bytes so lets go back to the the location where
 			// the a byte holds 8 MSB of a pixel
-			startX -= startX % 3;
+			startX -= startX % 2;
 		}
 
 		if(width == 0) {
@@ -574,9 +574,20 @@ void dng_save(void *mem, StreamInfo const &info, ControlList const &metadata,
 		// 		throw std::runtime_error("error writing DNG image data");
 		// }
 
+		std::cout << "startX: " << startX << std::endl;
+		std::cout << "endX: " << endX << std::endl;
+		std::cout << "startY: " << startY << std::endl;
+		std::cout << "endY: " << endY << std::endl;
+		std::cout << "width: " << width << std::endl;
+		std::cout << "height: " << height << std::endl;
+		std::cout << "roix: " << options->roi_x << std::endl;
+		std::cout << "roiy: " << options->roi_y << std::endl;
+		std::cout << "roi_width: " << options->roi_width << std::endl;
+		std::cout << "roi_height: " << options->roi_height << std::endl;
+
 		for (unsigned int y = startY; y < endY; y++)
 		{
-			if (TIFFWriteScanline(tif, &buf8bit[((info.width * bytesPerPixel) * y) + startX], y, 0) != 1)
+			if (TIFFWriteScanline(tif, &buf8bit[((info.width * bytesPerPixel) * y) + (startX * bytesPerPixel)], y, 0) != 1)
 				throw std::runtime_error("error writing DNG image data");
 		}
 

--- a/image/image.hpp
+++ b/image/image.hpp
@@ -14,6 +14,7 @@
 #include <libcamera/controls.h>
 
 #include "core/stream_info.hpp"
+#include "core/options.hpp"
 
 struct StillOptions;
 
@@ -29,7 +30,7 @@ void yuv_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 // In dng.cpp:
 void dng_save(void *mem, StreamInfo const &info,
 			  libcamera::ControlList const &metadata, std::string const &filename, std::string const &cam_model,
-			  StillOptions const *options);
+			  Options const *options);
 
 // In png.cpp:
 void png_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const &info,

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -69,7 +69,7 @@ void FileOutput::saveDng(void *mem) {
 	StreamInfo *info = this->getStreamInfo();
 
 	// TODO decide on camera name
-	dng_save(mem, *info, mockControlList, filename, "mock-camera-model", static_cast<const Options*>(options_));
+	dng_save(mem, *info, mockControlList, filename, "mock-camera-model", (const Options*)options_);
 }
 
 void FileOutput::openFile(int64_t timestamp_us)

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -69,7 +69,7 @@ void FileOutput::saveDng(void *mem) {
 	StreamInfo *info = this->getStreamInfo();
 
 	// TODO decide on camera name
-	dng_save(mem, *info, mockControlList, filename, "mock-camera-model", static_cast<Options*>(options_));
+	dng_save(mem, *info, mockControlList, filename, "mock-camera-model", static_cast<const Options*>(options_));
 }
 
 void FileOutput::openFile(int64_t timestamp_us)

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -69,7 +69,7 @@ void FileOutput::saveDng(void *mem) {
 	StreamInfo *info = this->getStreamInfo();
 
 	// TODO decide on camera name
-	dng_save(mem, *info, mockControlList, filename, "mock-camera-model", (const Options*)options_);
+	dng_save(mem, *info, mockControlList, filename, "mock-camera-model", options_);
 }
 
 void FileOutput::openFile(int64_t timestamp_us)

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -75,7 +75,7 @@ void FileOutput::saveDng(void *mem) {
 	std::string filename = fileNameManager_.getNextFileName();
 
 	// TODO decide on camera name
-	dng_save(mem, mockInfo, mockControlList, filename, "mock-camera-model", NULL);
+	dng_save(mem, this->streamInfo_, mockControlList, filename, "mock-camera-model", NULL);
 }
 
 void FileOutput::openFile(int64_t timestamp_us)

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -69,7 +69,7 @@ void FileOutput::saveDng(void *mem) {
 	StreamInfo *info = this->getStreamInfo();
 
 	// TODO decide on camera name
-	dng_save(mem, *info, mockControlList, filename, "mock-camera-model", NULL);
+	dng_save(mem, *info, mockControlList, filename, "mock-camera-model", static_cast<Options*>(options_));
 }
 
 void FileOutput::openFile(int64_t timestamp_us)

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -64,18 +64,12 @@ void FileOutput::saveFile(void *mem, size_t size, int64_t timestamp_us, uint32_t
 }
 
 void FileOutput::saveDng(void *mem) {
-	// TODO figure out how to not mock steamInfo
 	libcamera::ControlList mockControlList;
-
-	StreamInfo mockInfo;
-	mockInfo.width = 4056;
-	mockInfo.height = 3040;
-	mockInfo.stride = 6112;
-	mockInfo.pixel_format = libcamera::formats::SBGGR12_CSI2P;
 	std::string filename = fileNameManager_.getNextFileName();
+	StreamInfo *info = this->getStreamInfo();
 
 	// TODO decide on camera name
-	dng_save(mem, this->streamInfo_, mockControlList, filename, "mock-camera-model", NULL);
+	dng_save(mem, *info, mockControlList, filename, "mock-camera-model", NULL);
 }
 
 void FileOutput::openFile(int64_t timestamp_us)

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -15,7 +15,7 @@
 
 Output::Output(VideoOptions const *options)
 	: options_(options), fp_timestamps_(nullptr), state_(WAITING_KEYFRAME), time_offset_(0), last_timestamp_(0),
-	  buf_metadata_(std::cout.rdbuf()), of_metadata_()
+	  buf_metadata_(std::cout.rdbuf()), of_metadata_(), streamInfo_(NULL)
 {
 	if (!options->save_pts.empty())
 	{

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -15,7 +15,7 @@
 
 Output::Output(VideoOptions const *options)
 	: options_(options), fp_timestamps_(nullptr), state_(WAITING_KEYFRAME), time_offset_(0), last_timestamp_(0),
-	  buf_metadata_(std::cout.rdbuf()), of_metadata_(), streamInfo_(NULL)
+	  buf_metadata_(std::cout.rdbuf()), of_metadata_()
 {
 	if (!options->save_pts.empty())
 	{

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -27,7 +27,7 @@ public:
 	void setStreamInfo(StreamInfo *info) {
 		this->streamInfo_ = info;
 	}
-	void getStreamInfo() {
+	Streaminfo* getStreamInfo() {
 		return this->streamInfo_;
 	}
 

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -25,7 +25,7 @@ public:
 	void OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe);
 	void MetadataReady(libcamera::ControlList &metadata);
 	void setStreamInfo(StreamInfo info) {
-		this.streamInfo_ = info
+		this->streamInfo_ = info
 	}
 
 protected:

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -27,6 +27,7 @@ public:
 	void setStreamInfo(StreamInfo info) {
 		this->streamInfo_ = info;
 	}
+	StreamInfo streamInfo_;
 
 protected:
 	enum Flag
@@ -55,7 +56,6 @@ private:
 	std::ofstream of_metadata_;
 	bool metadata_started_ = false;
 	std::queue<libcamera::ControlList> metadata_queue_;
-	StreamInfo streamInfo_;
 };
 
 void start_metadata_output(std::streambuf *buf, std::string fmt);

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -27,7 +27,7 @@ public:
 	void setStreamInfo(StreamInfo* info) {
 		this->streamInfo_ = info;
 	}
-	Streaminfo* getStreamInfo() {
+	StreamInfo* getStreamInfo() {
 		return this->streamInfo_;
 	}
 

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -24,10 +24,10 @@ public:
 	virtual void Signal(); // a derived class might redefine what this means
 	void OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe);
 	void MetadataReady(libcamera::ControlList &metadata);
-	void setStreamInfo(StreamInfo *info) {
+	void setStreamInfo(StreamInfo* info) {
 		this->streamInfo_ = info;
 	}
-	Streaminfo *getStreamInfo() {
+	Streaminfo* getStreamInfo() {
 		return this->streamInfo_;
 	}
 
@@ -58,7 +58,7 @@ private:
 	std::ofstream of_metadata_;
 	bool metadata_started_ = false;
 	std::queue<libcamera::ControlList> metadata_queue_;
-	StreamInfo *streamInfo_ = nullptr;
+	StreamInfo* streamInfo_ = nullptr;
 };
 
 void start_metadata_output(std::streambuf *buf, std::string fmt);

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -24,10 +24,12 @@ public:
 	virtual void Signal(); // a derived class might redefine what this means
 	void OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe);
 	void MetadataReady(libcamera::ControlList &metadata);
-	void setStreamInfo(StreamInfo info) {
+	void setStreamInfo(StreamInfo *info) {
 		this->streamInfo_ = info;
 	}
-	StreamInfo streamInfo_;
+	void getStreamInfo() {
+		return this->streamInfo_;
+	}
 
 protected:
 	enum Flag
@@ -56,6 +58,7 @@ private:
 	std::ofstream of_metadata_;
 	bool metadata_started_ = false;
 	std::queue<libcamera::ControlList> metadata_queue_;
+	StreamInfo *streamInfo_ = nullptr;
 };
 
 void start_metadata_output(std::streambuf *buf, std::string fmt);

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -12,6 +12,7 @@
 #include <atomic>
 
 #include "core/video_options.hpp"
+#include "core/stream_info.hpp"
 
 class Output
 {
@@ -23,6 +24,9 @@ public:
 	virtual void Signal(); // a derived class might redefine what this means
 	void OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe);
 	void MetadataReady(libcamera::ControlList &metadata);
+	void setStreamInfo(StreamInfo info) {
+		this.streamInfo_ = info
+	}
 
 protected:
 	enum Flag
@@ -51,6 +55,7 @@ private:
 	std::ofstream of_metadata_;
 	bool metadata_started_ = false;
 	std::queue<libcamera::ControlList> metadata_queue_;
+	StreamInfo streamInfo_;
 };
 
 void start_metadata_output(std::streambuf *buf, std::string fmt);

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -25,7 +25,7 @@ public:
 	void OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe);
 	void MetadataReady(libcamera::ControlList &metadata);
 	void setStreamInfo(StreamInfo info) {
-		this->streamInfo_ = info
+		this->streamInfo_ = info;
 	}
 
 protected:

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -27,7 +27,7 @@ public:
 	void setStreamInfo(StreamInfo *info) {
 		this->streamInfo_ = info;
 	}
-	Streaminfo* getStreamInfo() {
+	Streaminfo *getStreamInfo() {
 		return this->streamInfo_;
 	}
 


### PR DESCRIPTION
I did a little more than just set the stream info in this MR

1. Allow StreamInfo to be placed on the Output class (the class responsible for writing files to disk). This is necessary so we can pass stream information into the function that writes the DNG to disk.
2. Add 12 bit and 10 bit dng packing.
3. Extend option->roi to be used in the DNG creation process. This allows for much smaller images.